### PR TITLE
EOF error when item.Value is zero value

### DIFF
--- a/memd.go
+++ b/memd.go
@@ -1,10 +1,15 @@
 package memd
 
 import (
+	"errors"
+	"log"
+
 	"github.com/douban/libmc/golibmc"
 	"github.com/ugorji/go/codec"
-	"log"
 )
+
+// ErrEmptyValue is returned by FromItem when the size of item.Value is zero.
+var ErrEmptyValue = errors.New("cannot decode from empty value")
 
 // Client is wrapper of *golibmc.Client.
 type Client struct {
@@ -121,6 +126,9 @@ func (c *Client) ToItem(key string, _val interface{}, exp int64) (*golibmc.Item,
 
 // FromItem ... deserialize item.Value
 func (c *Client) FromItem(item *golibmc.Item, val interface{}) error {
+	if len(item.Value) == 0 {
+		return ErrEmptyValue
+	}
 	return codec.NewDecoderBytes(item.Value, c.serializer).Decode(val)
 }
 

--- a/memd_test.go
+++ b/memd_test.go
@@ -1,11 +1,12 @@
 package memd
 
 import (
-	"github.com/douban/libmc/golibmc"
-	"github.com/ugorji/go/codec"
 	"log"
 	"testing"
 	"time"
+
+	"github.com/douban/libmc/golibmc"
+	"github.com/ugorji/go/codec"
 )
 
 type Result struct {
@@ -123,5 +124,27 @@ func ResultSerializer(t *testing.T) {
 	}
 	if res.Hoge != 1 || res.Fuga != "aaa" {
 		t.Error("invalid cache")
+	}
+}
+
+func TestResultFromItem(t *testing.T) {
+	c := New(golibmc.SimpleNew([]string{"localhost:11211"}))
+
+	tests := []struct {
+		b   []byte
+		err error
+	}{
+		{[]byte(``), ErrEmptyValue},
+		{[]byte(`{}`), nil},
+		{[]byte(`{"foo":"bar"}`), nil},
+	}
+
+	for _, tt := range tests {
+		item := &golibmc.Item{Value: tt.b}
+		var v map[string]interface{}
+		err := c.FromItem(item, &v)
+		if err != tt.err {
+			t.Errorf("FromItem(%+v, %s) = %#v", item, v, err)
+		}
 	}
 }


### PR DESCRIPTION
`FromItem` returns "EOF" when `item.Value` is zero value.

```go
item := &golibmc.Item{}
var val interface{}
err := client.FromItem(item, &val) 
fmt.Printf("%#v", err) // returns errors.errorString{s:"EOF"}
```
But, for me, it seems hard to understand when the error happens and I want to treat it as a specific error value. So, I think it should return `ErrEmptyValue` when a value is empty.

How about this idea?